### PR TITLE
Add async_first method

### DIFF
--- a/aiocqlengine/models.py
+++ b/aiocqlengine/models.py
@@ -35,6 +35,13 @@ class AioModel(Model):
         ).async_delete()
 
     @classmethod
+    async def async_first(cls):
+        """
+        This is a pass-through to the model objects().async_first()
+        """
+        return await cls.objects.async_first()
+
+    @classmethod
     async def async_all(cls):
         """
         Returns a queryset representing all stored objects.

--- a/aiocqlengine/query.py
+++ b/aiocqlengine/query.py
@@ -290,6 +290,16 @@ class AioQuerySet(ModelQuerySet):
                     self._if_exists).using(connection=self._connection
                                            ).async_save())
 
+    async def async_first(self):
+        await self._async_execute_query()
+
+        try:
+            obj = self[0]
+        except IndexError:
+            return None
+        
+        return obj
+
     async def async_all(self):
         await self._async_execute_query()
         return self

--- a/tests/test_aiocqlengine.py
+++ b/tests/test_aiocqlengine.py
@@ -16,6 +16,7 @@ class User(AioModel):
 async def test_queryset_async_functions(cqlengine_management):
     """test cqlengine Model async functions:
     Model.objects.async_get()
+    Model.objects.async_first()
     Model.objects.async_all()
     Model.objects.async_create()
     Model.objects(id=obj_id).async_update()
@@ -28,7 +29,8 @@ async def test_queryset_async_functions(cqlengine_management):
     users = await User.objects.async_all()
     user = users[0]
     _user = await User.objects.async_get(user_id=user.user_id)
-    assert user.username == _user.username == username1
+    _user2 = await User.async_first()
+    assert user.username == _user.username == _user2.username == username1
 
     # test DML query: Model.objects(id=obj_id).async_update()
     username2 = "test-username-2"
@@ -41,6 +43,7 @@ async def test_queryset_async_functions(cqlengine_management):
 async def test_model_async_functions(cqlengine_management):
     """test cqlengine Model async functions:
     Model.async_get()
+    Model.async_first()
     Model.async_all()
     Model.async_create()
     obj.async_update()
@@ -49,13 +52,14 @@ async def test_model_async_functions(cqlengine_management):
     """
     cqlengine_management.sync_table(User)
 
-    # test: Model.async_create(), Model.async_all(), Model.async_get()
+    # test: Model.async_create(), Model.async_all(), Model.async_get(), Model.async_first()
     username1 = "test-username-1"
     await User.async_create(user_id=uuid.uuid4(), username=username1)
     users = await User.async_all()
     user = users[0]
     _user = await User.async_get(user_id=user.user_id)
-    assert user.username == _user.username == username1
+    _user2 = await User.async_first()
+    assert user.username == _user.username == _user2.username == username1
 
     # test: obj.async_save()
     username2 = "test-username-2"


### PR DESCRIPTION
This PR adds an `async_first` method to ensure compatibility with the [DataStax Python Driver](https://github.com/datastax/python-driver/blob/master/cassandra/cqlengine/query.py#L605).