### PR TITLE
Use poetry-core as build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,5 @@ pylava = "^0.2.2"
 yapf = "^0.28.0"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The masonry has been moved into poetry-core.  Using this makes repacking for Linux and conda easier.